### PR TITLE
Changed main purple a little bit to fix the buttons

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -7,7 +7,7 @@ $blue: #2E5DD4;
 $dark-blue: #364D5E;
 $brown: #94442B;
 $deep-purple: #5547AA;
-$main-purple: #9A6CD5;
+$main-purple: #8F5DD0;
 $light-purple: #D3CEE9;
 $light-grey: #E0E7EC;
 $lighter-grey: #F3F5F8;


### PR DESCRIPTION
Bootstrap checked for contrast ratio for accessibility reasons, and it was changing out buttons to a black text. Now it's fixed.