### PR TITLE
Styling messages

### DIFF
--- a/app/assets/stylesheets/components/_chatroom.scss
+++ b/app/assets/stylesheets/components/_chatroom.scss
@@ -9,17 +9,25 @@
     background: $white;
     height: 100%;
     margin: 0 -15px;
-    padding: 20px 15px;
+    padding: 20px 15px 10px;
     overflow: scroll;
   }
 
-  #new_message {
+  .add-message {
     background: $light-grey;
     margin: 0 -15px;
     padding: 10px 15px;
-
-    .form-group {
-      margin-bottom: 0;
+    .form-group, .message_content {
+      margin-bottom: 0!important;
+    }
+    .purple-circle-button {
+      border: none;
+      text-indent: -99999px;
+      width: 30px;
+      background-image: asset-url('icons/send.svg');
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 20px;
     }
   }
 }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -11,3 +11,4 @@
 @import "map";
 @import "banner";
 @import "events";
+@import "message";

--- a/app/assets/stylesheets/components/_message.scss
+++ b/app/assets/stylesheets/components/_message.scss
@@ -1,0 +1,27 @@
+// To style the wrapping div
+.message-row {
+  margin-bottom: 10px;
+}
+
+// To style the message itself
+.sender-style, .receiver-style {
+  width: 70%;
+  max-width: 400px;
+  padding: 10px 15px;
+}
+
+.sender-style {
+  background-color: $main-purple;
+  border-radius: 5px 5px 0 5px;
+  p, small {
+    color: $white;
+  }
+}
+
+.receiver-style {
+  background-color: $light-purple;
+  border-radius: 5px 5px 5px 0;
+  p, small {
+    color: $dark-grey;
+  }
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,10 +8,12 @@ class MessagesController < ApplicationController
     if @message.save
       ChatroomChannel.broadcast_to(
         @chatroom,
-        render_to_string(partial: "message", locals: {message: @message})
+        message: render_to_string(partial: "message", locals: { message: @message }),
+        sender_id: @message.user.id
       )
       head :ok
     else
+      @messages = @chatroom.messages.order('messages.created_at asc')
       render "chatrooms/show", status: :unprocessable_entity
     end
   end

--- a/app/javascript/controllers/chatroom_subscription_controller.js
+++ b/app/javascript/controllers/chatroom_subscription_controller.js
@@ -3,7 +3,7 @@ import { createConsumer } from "@rails/actioncable"
 
 // Connects to data-controller="chatroom-subscription"
 export default class extends Controller {
-  static values = { chatroomId: Number }
+  static values = { chatroomId: Number, currentUserId: Number }
   static targets = ["messages"]
 
   connect() {
@@ -11,7 +11,8 @@ export default class extends Controller {
       { channel: "ChatroomChannel", id: this.chatroomIdValue },
       { received: data => this.#insertMessageAndScrollDown(data) }
     )
-    console.log(`Subscribed to the chatroom with the id ${this.chatroomIdValue}.`)
+    console.log(`Subscribed to the chatroom with the id ${this.chatroomIdValue}.`);
+    this.messagesTarget.scrollTo(0, this.messagesTarget.scrollHeight);
   }
   resetForm(event) {
     event.target.reset()
@@ -20,8 +21,32 @@ export default class extends Controller {
     console.log("Unsubscribed from the chatroom")
     this.channel.unsubscribe()
   }
+  #buildMessageElement(currentUserIsSender, message) {
+    return `
+      <div class="message-row d-flex ${this.#justifyClass(currentUserIsSender)}">
+        <div class="${this.#userStyleClass(currentUserIsSender)}">
+          ${message}
+        </div>
+      </div>
+    `
+  }
+  #justifyClass(currentUserIsSender) {
+    return currentUserIsSender ? "justify-content-end" : "justify-content-start"
+  }
+  #userStyleClass(currentUserIsSender) {
+    return currentUserIsSender ? "sender-style" : "receiver-style"
+  }
   #insertMessageAndScrollDown(data) {
-    this.messagesTarget.insertAdjacentHTML("beforeend", data)
+    // Logic to know if the sender is the current_user
+    const currentUserIsSender = this.currentUserIdValue === data.sender_id
+
+    // Creating the whole message from the `data.message` String
+    const messageElement = this.#buildMessageElement(currentUserIsSender, data.message)
+
+    console.log(this.messagesTarget);
+
+    // Inserting the `message` in the DOM
+    this.messagesTarget.insertAdjacentHTML("beforeend", messageElement)
     this.messagesTarget.scrollTo(0, this.messagesTarget.scrollHeight)
   }
 }

--- a/app/javascript/controllers/chatroom_subscription_controller.js
+++ b/app/javascript/controllers/chatroom_subscription_controller.js
@@ -4,7 +4,7 @@ import { createConsumer } from "@rails/actioncable"
 // Connects to data-controller="chatroom-subscription"
 export default class extends Controller {
   static values = { chatroomId: Number, currentUserId: Number }
-  static targets = ["messages"]
+  static targets = ["messages", "input"]
 
   connect() {
     this.channel = createConsumer().subscriptions.create(
@@ -15,6 +15,9 @@ export default class extends Controller {
     this.messagesTarget.scrollTo(0, this.messagesTarget.scrollHeight);
   }
   resetForm(event) {
+    if (this.inputTarget.value) {
+      this.inputTarget.classList.remove("is-invalid");
+    };
     event.target.reset()
   }
   disconnect() {
@@ -42,8 +45,6 @@ export default class extends Controller {
 
     // Creating the whole message from the `data.message` String
     const messageElement = this.#buildMessageElement(currentUserIsSender, data.message)
-
-    console.log(this.messagesTarget);
 
     // Inserting the `message` in the DOM
     this.messagesTarget.insertAdjacentHTML("beforeend", messageElement)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,10 @@
 class Message < ApplicationRecord
   belongs_to :chatroom
   belongs_to :user
+
+  validates :content, presence: true
+
+  def sender?(a_user)
+    user.id == a_user.id
+  end
 end

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,22 +1,30 @@
 <div class="chatroom"
   data-controller="chatroom-subscription"
-  data-chatroom-subscription-chatroom-id-value="<%= @chatroom.id %>">
+  data-chatroom-subscription-chatroom-id-value="<%= @chatroom.id %>"
+  data-chatroom-subscription-current-user-id-value="<%= current_user.id %>">
   <%# <h1>Your chat with username</h1> %>
 
   <div class="messages" data-chatroom-subscription-target="messages">
     <% @messages.each do |message| %>
-      <%= render "messages/message", message: message %>
+      <div class="message-row d-flex <%= message.sender?(current_user) ? 'justify-content-end' : 'justify-content-start' %>">
+        <div class="<%= message.sender?(current_user) ? 'sender-style' : 'receiver-style' %>">
+          <%= render "messages/message", message: message %>
+        </div>
+      </div>
     <% end %>
   </div>
 
-  <%= simple_form_for [@chatroom, @message],
-    html: { data: { action: "turbo:submit-end->chatroom-subscription#resetForm" }, class: "d-flex" } do |f|
-  %>
-    <%= f.input :content, as: :string,
-      label: false,
-      placeholder: "Type message",
-      wrapper_html: {class: "flex-grow-1"}
+  <div class="add-message">
+    <%= simple_form_for [@chatroom, @message],
+      html: { data: { action: "turbo:submit-end->chatroom-subscription#resetForm" }, class: "d-flex" } do |f|
     %>
-    <%= f.submit "Send", class: "btn btn-primary ms-1" %>
-  <% end %>
+      <%= f.input :content, as: :string,
+        label: false,
+        required: true,
+        placeholder: "Type message",
+        wrapper_html: {class: "flex-grow-1"}
+      %>
+      <%= f.submit "Send", class: "purple-circle-button" %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -22,7 +22,8 @@
         label: false,
         required: true,
         placeholder: "Type message",
-        wrapper_html: {class: "flex-grow-1"}
+        wrapper_html: {class: "flex-grow-1"},
+        input_html: { data: { chatroom_subscription_target: "input" } }
       %>
       <%= f.submit "Send", class: "purple-circle-button" %>
     <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -3,5 +3,5 @@
     <strong><em><%= message.user.first_name %></em></strong>
     <em>- <%= message.created_at.strftime("%a %b %e at %l:%M %p") %></em>
   </small>
-  <p class="m-0"><%= message.content %></p>
+  <p class="m-0 small"><%= message.content %></p>
 </div>


### PR DESCRIPTION
This was pretty much following [Stephane's tutorial](https://kitt.lewagon.com/knowledge/tutorials/rails_action_cable_chat_message_styling). I just added the styling to make it closer to our design:

![Screen Shot 2022-12-05 at 8 08 23 PM](https://user-images.githubusercontent.com/108884517/205781244-0785daa1-6bfc-48b1-b744-7cd23abe92e7.png)

I also fixed the error for the empty messages after my last PR, and created a stimulus target to remove the invalid bootstrap styling when sending a successful message.

*There is only the back button on the bar pending for the chatroom show view, but it's going to be done in a partial on another PR.