### PR TITLE
Fixed the back button loop on some pages

### DIFF
--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,5 +1,5 @@
 <% other_user = @chatroom.other_user(current_user) %>
-<%= render 'shared/back_bar', text: "#{other_user.first_name} #{other_user.last_name}", user: other_user, link: my_messages_path %>
+<%= render 'shared/back_bar', text: "#{other_user.first_name} #{other_user.last_name}", user: other_user %>
 <div class="chatroom"
   data-controller="chatroom-subscription"
   data-chatroom-subscription-chatroom-id-value="<%= @chatroom.id %>"

--- a/app/views/shared/_back_bar.html.erb
+++ b/app/views/shared/_back_bar.html.erb
@@ -1,8 +1,7 @@
 <div class="back-bar navbar navbar-lewagon">
   <div class="container">
     <div class="d-flex align-items-center justify-content-start">
-      <% new_link = defined?(link) ? link : :back %>
-      <%= link_to new_link do %>
+      <%= link_to "javascript:history.back()" do %>
         <%= image_tag "icons/arrow-left.svg", alt: "go-back", class: "me-3 arrow" %>
       <% end %>
       <% if defined?(user) %>


### PR DESCRIPTION
I created an ugly loop when using the back button in some pages. This solves it. It will now rely on the browser's back page in history instead of going to the last link in rails.