### PR TITLE
Fix for fake addresses

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -5,4 +5,8 @@
 .mapboxgl-popup-content {
   text-align: center;
   font-family: "Open Sans", sans-serif;
+  padding: 15px 10px;
+  h2, p {
+    margin: 0;
+  }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,14 @@ class UsersController < ApplicationController
       geocoded_search_results = Geocoder.search(params[:query])
       top_result = geocoded_search_results.first
       @users = policy_scope(User).near(top_result.address, 5)
+      @users_sorted = @users
     else
-      @users = policy_scope(User)
+      @users = policy_scope(User).where.not(latitude: nil)
+      if current_user.latitude.nil?
+        @users_sorted = @users
+      else
+        @users_sorted = @users.sort_by { |user| user.distance_to([current_user.latitude, current_user.longitude]).round(1) }
+      end
     end
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,6 +23,7 @@
                     autofocus: true,
                     input_html: { autocomplete: "last_name" }%>
         <%= f.input :address,
+                    hint: "This won't be public! Just make sure it's a real address or you will miss a lot of our features",
                     required: true,
                     input_html: { autocomplete: "address" } %>
         <%= f.input :gender, collection: User::GENDERS,
@@ -51,7 +52,7 @@
                   input_html: { autocomplete: "upload an avatar"} %>
 
         <%= f.input :password,
-                    hint: "leave it blank if you don't want to change it",
+                    hint: "Leave it blank if you don't want to change it",
                     required: false,
                     input_html: { autocomplete: "new-password" } %>
         <%= f.input :password_confirmation,

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,7 +1,8 @@
 <%= simple_form_for(@event) do |f| %>
   <%= f.input :date, as: :datetime, html5: true %>
   <%= f.input :title %>
-  <%= f.input :address %>
+  <%= f.input :address,
+              hint: "If it's not a real address it won't show in the search!" %>
   <%= f.input :description %>
   <%= f.input :status, collection: Event::STATUS %>
   <%= f.input :photo, as: :file %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -15,7 +15,7 @@
     data-map-markers-value="<%= @markers.to_json %>"
     data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>">
   </div>
-  <% @events.sort_by {|event| event.distance_to([current_user.latitude, current_user.longitude]).round(1) }.each do |event| %>
+  <% @events_sorted.each do |event| %>
     <% if event.date.future? %>
       <%= render "shared/event", event: event %>
     <% end %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -2,7 +2,8 @@
   <p>Date </p>
   <%= f.date_field :date, as: :datetime, html5: true, min: DateTime.now %>
   <%= f.input :title, required: false %>
-  <%= f.input :address %>
+  <%= f.input :address,
+              hint: "If it's not a real address it won't show in the search!" %>
   <%= f.input :description, required: false %>
   <%= f.input :photo, as: :file, label: "Photo (optional)" %>
   <%= f.submit %>

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -9,6 +9,7 @@
               autofocus: true,
               input_html: { autocomplete: "last_name" }%>
   <%= field.input :address,
+              hint: "This won't be public! Just make sure it's a real address or you will miss a lot of our features",
               required: true,
               input_html: { autocomplete: "address" } %>
   <%= field.input :gender, collection: User::GENDERS,

--- a/app/views/shared/_user.html.erb
+++ b/app/views/shared/_user.html.erb
@@ -19,7 +19,7 @@
       <% if user.reviews.exists? %>
         <%= render "shared/stars", average_rating: user.reviews.average(:rating).round(2) %>
       <% end %>
-      <% if user_signed_in? %>
+      <% if user_signed_in? && !current_user.latitude.nil? && !user.latitude.nil? %>
         <small class="text-end">
           <%# TODO %>
           <%="#{user.distance_to([current_user.latitude, current_user.longitude]).round(1)}"%> Km

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,7 +10,7 @@
       <a href="#" class="purple-circle-button"><%= image_tag "icons/sliders.svg", alt: "Advanced search", width: 20 %></a>
     <% end %>
   </div>
-  <% @users.sort_by {|user| user.distance_to([current_user.latitude, current_user.longitude]).round(1) }.each do |user| %>
+  <% @users_sorted.each do |user| %>
     <% if user != current_user %>
       <%= render "shared/user", user: user %>
     <% end %>


### PR DESCRIPTION
This is a fix for events and users:
1. It changes a couple of things in the styling of the map tooltips (sorry, I checked the map and decided to add it here 😅).
2. Creates the @events_sorted and @users_sorted in the controller, where it makes more sense to have them.
3. Adds hints for the addresses in the forms, to invite the user to add a real address.
4. Even if they add a fake address, the conditionals in the controller will make sure that we have a latitude before sorting, otherwise it's just the @events in default order.
5. Removes the sorting from the views since it's already in the controller.
6. Finally, in the user card, we check that the current user and the user from the card have a latitude before showing the distance.

This takes care of all the NaN on the user cards, and the search forms: If the user or the event doesn't have a real address, it won't show up in the search to avoid conflicts with the basic or the advanced search.

![Screen Shot 2022-12-08 at 10 59 04 PM](https://user-images.githubusercontent.com/108884517/206621166-f7c1952e-8beb-4cdb-a61a-13ea17c764a7.png)
![Screen Shot 2022-12-08 at 10 59 40 PM](https://user-images.githubusercontent.com/108884517/206621174-0280458f-f457-4114-b09e-afb0f23a5852.png)
![Screen Shot 2022-12-08 at 10 59 56 PM](https://user-images.githubusercontent.com/108884517/206621184-a8027eb4-b42c-462b-ac97-5dd3b28915ad.png)
