### PR TITLE
Added the logic to change back link on pages where the overlay was acting weird

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/back_bar' %>
+<%= render 'shared/back_bar', link: :back %>
 
 <h2>Edit my profile</h2>
 

--- a/app/views/shared/_back_bar.html.erb
+++ b/app/views/shared/_back_bar.html.erb
@@ -1,7 +1,8 @@
 <div class="back-bar navbar navbar-lewagon">
   <div class="container">
     <div class="d-flex align-items-center justify-content-start">
-      <%= link_to "javascript:history.back()" do %>
+      <% def_link = defined?(link) ? link : "javascript:history.back()" %>
+      <%= link_to def_link do %>
         <%= image_tag "icons/arrow-left.svg", alt: "go-back", class: "me-3 arrow" %>
       <% end %>
       <% if defined?(user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,8 @@
-<%= render 'shared/back_bar' %>
+<% if @user.id == current_user.id %>
+  <%= render 'shared/back_bar', link: :back %>
+<% else %>
+  <%= render 'shared/back_bar' %>
+<% end %>
 <div class="form-box mb-0">
   <div class="text-center">
     <% if @user.photo.key %>


### PR DESCRIPTION
This fixes the bug reported by @SaneCashew. If we use rails `:back` it reloads the default functionality in the previous page. I only added it to _My profile_ and _Edit profile_ since the  `javascript:history.back()` fixes some other loops that we had in the users/reviews.