### PR TITLE
Shorter text buttons

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -25,9 +25,18 @@
 }
 .button-block {
   gap: 10px;
+  align-content: stretch;
+  form.button_to {
+    display: flex;
+  }
+  .btn.w-100 {
+    display: flex!important;
+    justify-content: center;
+    align-items: center;
+  }
 }
 .btn.d-block, .btn.d-inline-block {
-  padding: 10px 15px;
+  padding: 10px 10px;
   line-height: 20px;
   border: none;
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -45,9 +45,14 @@ class EventsController < ApplicationController
     authorize @event
     @confirmed_guests = Guest.select { |guest| guest.event_id == @event.id && guest.status == "Accept" }
     @pending_guests = Guest.select { |guest| guest.event_id == @event.id && guest.status == "Pending" }
+    @invited_guests = Guest.select { |guest| guest.event_id == @event.id && guest.status == "Invited" }
     @include_guest = [@event.host_id]
     @confirmed_guests.each { |guest| @include_guest << guest.guest_id }
     @pending_guests.each { |guest| @include_guest << guest.guest_id }
+    @invited_guests.each { |guest| @include_guest << guest.guest_id }
+    @confirmed_guests_ids = @confirmed_guests.map { |guest| guest.guest_id }
+    @pending_guests_ids = @pending_guests.map { |guest| guest.guest_id }
+    @invited_guests_ids = @invited_guests.map { |guest| guest.guest_id }
     @markers = [
       {
         lat: @event.latitude,

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -29,7 +29,7 @@ class EventsController < ApplicationController
 
     if params[:date].present?
       date = DateTime.parse(params[:date]).to_i + 18_000
-      @events = @events.select { |event| date <= event.date.to_i && event.date.to_i <= (date + 60 * 60 * 24) }
+      @events = @events.select { |event| date <= event.date.to_i && event.date.to_i <= (date + (60 * 60 * 24)) }
     end
 
     @markers = @events.map do |event|

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -52,20 +52,12 @@
     data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"></div>
   </div>
 
-  <% if !@event.guests.empty? %>
+  <% if !@confirmed_guests.empty? %>
     <h2><%= pluralize( @confirmed_guests.count, 'Attendee') %></h2>
     <div class="component-container">
       <% @confirmed_guests.each do |guest| %>
-        <% if guest.status == "Accept" %>
-          <% user = User.find(guest.guest_id) %>
-          <%= render "shared/user", user: user %>
-          <% if user.id == current_user.id %>
-            <%= link_to "Decided not to show?", guest_path(guest), data: { turbo_method: :delete, turbo_confirm: "Are you sure you won't show up?" }, class: "btn btn-primary" %>
-          <% end %>
-        <% elsif guest.status == "Invited" && guest.guest_id == current_user.id %>
-          <%= button_to "You're gonna show up to this event!",  {:controller => "guests", :action => "accept", :event_id => @event.id, :guest_id => guest.id  },  {:method=>:patch, class: "btn btn-primary d-block w-100"} %>
-          <%= button_to "You can't make it? Let the host know.",  {:controller => "guests", :action => "reject", :event_id => @event.id, :guest_id => guest.id },  {:method=>:patch, class: "btn btn-secondary d-block w-100"} %>
-        <% end %>
+        <% user = User.find(guest.guest_id) %>
+        <%= render "shared/user", user: user %>
       <% end %>
     </div>
   <% end %>
@@ -105,13 +97,22 @@
   <% else %>
     <% if !@include_guest.include?(current_user.id) && @event.date.future? %>
       <%= button_to "Join event", {:controller => "guests", :action => "create", :guest_id => current_user.id, :event_id => @event.id} , {:method=>:post, class: "btn btn-primary d-block w-100 my-3"} %>
+    <% elsif @invited_guests_ids.include?(current_user.id) %>
+    <% guest = Guest.where(guest_id: current_user.id).first %>
+      <div class="d-flex button-block my-3">
+        <%= button_to "I'm going",  {:controller => "guests", :action => "accept", :event_id => @event.id, :guest_id => guest.id  },  {:method=>:patch, class: "btn btn-primary d-block w-100"} %>
+        <%= button_to "Can't make it",  {:controller => "guests", :action => "reject", :event_id => @event.id, :guest_id => guest.id },  {:method=>:patch, class: "btn btn-secondary d-block w-100"} %>
+      </div>
+    <% elsif @pending_guests_ids.include?(current_user.id) || @confirmed_guests_ids.include?(current_user.id) %>
+    <% guest = Guest.where(guest_id: current_user.id).first %>
+      <%= link_to "Decided not to show", guest_path(guest), data: { turbo_method: :delete, turbo_confirm: "Are you sure you won't show up?" }, class: "btn btn-primary d-block w-100 my-3" %>
     <% end %>
   <% end %>
   <% if @event.host_id == current_user.id && @event.date.future? %>
     <div class="d-flex button-block my-3">
-      <%= link_to "Edit this event", edit_event_path(@event), class: "btn btn-primary d-block w-100" %>
-      <%= link_to "Invite more people to this event", invite_partners_path(@event.id), class: "btn btn-primary d-block w-100" %>
-      <%= link_to "Delete", event_path(@event), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-primary d-block w-100" %>
+      <%= link_to "Edit event", edit_event_path(@event), class: "btn btn-primary d-block w-100" %>
+      <%= link_to "Invite partners", invite_partners_path(@event.id), class: "btn btn-primary d-block w-100" %>
+      <%= link_to "Delete", event_path(@event), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-secondary d-block w-100" %>
     </div>
   <% end %>
 </div>

--- a/app/views/partners/invite_partners_list.html.erb
+++ b/app/views/partners/invite_partners_list.html.erb
@@ -21,7 +21,7 @@
           <% if !@guests_ids.include?(friend.id) %>
             <%= button_to "Invite",  {:controller => "guests", :action => "invite", :event_id => @event.id, :guest_id => friend.id },  {:method=>:post, class: "btn btn-primary d-block w-100"} %>
           <% else %>
-            <%="#{friend.distance_to([current_user.latitude, current_user.longitude]).round(1)}"%> Km
+            <small class="text-end"><%="#{friend.distance_to([current_user.latitude, current_user.longitude]).round(1)}"%> Km</small>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
This fixes a bug with the buttons. When I was invited to an event I couldn't accept or decline now (it broke when we switched to @confirmed_guests.each). I also changed some texts (made them shorter) on the buttons so it looks better on mobile.

I also added a conditional so we don't show the Attendees title if there are none 😄 

![Screen Shot 2022-12-11 at 9 44 12 PM](https://user-images.githubusercontent.com/108884517/206949691-b766ba71-0241-449c-862b-c12257dd6092.png)
