### PR TITLE
Made loading page public, and changed timeout for erasing text

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: :home
+  skip_before_action :authenticate_user!, only: %i[home loading]
 
   def home
     if user_signed_in?

--- a/app/javascript/controllers/typewriter_controller.js
+++ b/app/javascript/controllers/typewriter_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     const peopleArray = ['- Bruce Lee', '- Renzo Gracie', '- John Danaher'];
 
     const typingDelay = 100;
-    const erasingDelay = 100;
+    const erasingDelay = 50;
     const newTextDelay = 5000; // Delay between current and next text
 
     let charIndex = 0;


### PR DESCRIPTION
This is a very simple PR that makes the /loading page public (not part of the journey but it made sense to have both home and loading for visitors), and changed the timeout interval for the erasing part, since it was taking the same amount of time than typing, just to make it look a bit more natural.