### PR TITLE
Events forms styling and JS

### DIFF
--- a/app/assets/stylesheets/components/_events.scss
+++ b/app/assets/stylesheets/components/_events.scss
@@ -52,3 +52,16 @@
     }
   }
 }
+.attendee-list {
+  h2 {
+    margin-top: 10px;
+  }
+  .hide-attendees {
+    > * {
+      display: none;
+    }
+    > .card-box:nth-child(1), > .card-box:nth-child(2) {
+      display: block;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -12,6 +12,7 @@ form.button_to {
   border: 1px solid $light-grey;
   line-height: 20px;
   padding: 9px 10px;
+  height: 40px;
 }
 .form-control.search-icon {
   padding-left: 30px;

--- a/app/javascript/controllers/attendee_list_controller.js
+++ b/app/javascript/controllers/attendee_list_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="attendee-list"
+export default class extends Controller {
+  static targets = ["link", "list"];
+
+  connect() {
+    const linkAttendees = this.linkTarget;
+    const listAttendees = this.listTarget;
+    const count = listAttendees.childElementCount;
+
+    if (count <= 3) {
+      linkAttendees.style.display = 'none';
+    } else {
+      listAttendees.classList.add('hide-attendees');
+      linkAttendees.addEventListener("click", (event) => {
+        event.preventDefault();
+        if (linkAttendees.innerText == "See all") {
+          linkAttendees.innerText = "Hide";
+          listAttendees.classList.remove('hide-attendees');
+        } else if (linkAttendees.innerText == "Hide") {
+          linkAttendees.innerText = "See all";
+          listAttendees.classList.add('hide-attendees');
+        }
+
+      });
+    }
+
+  }
+}

--- a/app/javascript/controllers/attendee_list_controller.js
+++ b/app/javascript/controllers/attendee_list_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
     const listAttendees = this.listTarget;
     const count = listAttendees.childElementCount;
 
-    if (count <= 3) {
+    if (count <= 2) {
       linkAttendees.style.display = 'none';
     } else {
       listAttendees.classList.add('hide-attendees');

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import AttendeeListController from "./attendee_list_controller"
+application.register("attendee-list", AttendeeListController)
+
 import ChatroomSubscriptionController from "./chatroom_subscription_controller"
 application.register("chatroom-subscription", ChatroomSubscriptionController)
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,9 +1,16 @@
-<%= simple_form_for(@event) do |f| %>
-  <%= f.input :date, as: :datetime, html5: true %>
-  <%= f.input :title %>
-  <%= f.input :address,
-              hint: "If it's not a real address it won't show up on the map or in the search!" %>
-  <%= f.input :description %>
-  <%= f.input :photo, as: :file %>
-  <%= f.submit %>
-<% end %>
+<%= render 'shared/back_bar' %>
+<h1>Edit event</h1>
+<div class="component-container">
+  <div class="form-box bg-white new-review">
+    <%= simple_form_for(@event) do |f| %>
+      <label class="form-label" for="event_date">Date *</label>
+      <%= f.datetime_field :date, as: :datetime, html5: true, min: DateTime.now, class: "form-control mb-3" %>
+      <%= f.input :title %>
+      <%= f.input :address,
+                  hint: "If it's not a real address it won't show up on the map or in the search!" %>
+      <%= f.input :description %>
+      <%= f.input :photo, as: :file %>
+      <%= f.submit class: "btn btn-primary d-block w-100" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,10 +1,17 @@
-<%= simple_form_for(@event) do |f| %>
-  <p>Date </p>
-  <%= f.date_field :date, as: :datetime, html5: true, min: DateTime.now %>
-  <%= f.input :title, required: false %>
-  <%= f.input :address,
-              hint: "If it's not a real address it won't show in the search!" %>
-  <%= f.input :description, required: false %>
-  <%= f.input :photo, as: :file, label: "Photo (optional)" %>
-  <%= f.submit %>
-<% end %>
+<%= render 'shared/back_bar' %>
+<h1>Create an event</h1>
+<div class="component-container">
+  <div class="form-box bg-white">
+    <%= simple_form_for(@event) do |f| %>
+      <label class="form-label" for="event_date">Date *</label>
+      <%= f.datetime_field :date, as: :datetime, html5: true, min: DateTime.now, class: "form-control mb-3" %>
+      <%= f.input :title, required: true %>
+      <%= f.input :address,
+                  required: true,
+                  hint: "If it's not a real address it won't show in the search!" %>
+      <%= f.input :description, required: true %>
+      <%= f.input :photo, as: :file, label: "Photo (optional)" %>
+      <%= f.submit class: "btn btn-primary d-block w-100" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -58,12 +58,17 @@
   </div>
 
   <% if !@confirmed_guests.empty? %>
-    <h2><%= pluralize( @confirmed_guests.count, 'Attendee') %></h2>
-    <div class="component-container">
-      <% @confirmed_guests.each do |guest| %>
-        <% user = User.find(guest.guest_id) %>
-        <%= render "shared/user", user: user %>
-      <% end %>
+    <div class="attendee-list" data-controller="attendee-list">
+      <div class="d-flex justify-content-between align-items-center">
+        <h2><%= pluralize( @confirmed_guests.count, 'Attendee') %></h2>
+        <a href="#" class="fw-bold" data-attendee-list-target="link">See all</a>
+      </div>
+      <div class="component-container" data-attendee-list-target="list">
+        <% @confirmed_guests.each do |guest| %>
+          <% user = User.find(guest.guest_id) %>
+          <%= render "shared/user", user: user %>
+        <% end %>
+      </div>
     </div>
   <% end %>
 


### PR DESCRIPTION
1. This PR adds basic styling for event's forms:
![Screen Shot 2022-12-13 at 5 36 03 PM](https://user-images.githubusercontent.com/108884517/207459609-204daca2-d9ff-4c81-8587-92f57e224de6.png)

2. It also adds JS to change the number of attendees that we can see, so the screen is not too long when there are many.
- On load:
![Screen Shot 2022-12-13 at 5 32 21 PM](https://user-images.githubusercontent.com/108884517/207459344-9182354c-a93a-4a41-a7e0-1f2d6d370e21.png)
- On click or tap:
![Screen Shot 2022-12-13 at 5 32 33 PM](https://user-images.githubusercontent.com/108884517/207459384-596bd97e-b0bc-4454-b60e-3711169a3a15.png)
